### PR TITLE
Closure builder py3

### DIFF
--- a/closure/bin/build/closurebuilder.py
+++ b/closure/bin/build/closurebuilder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009 The Closure Library Authors. All Rights Reserved.
 #
@@ -276,7 +276,7 @@ https://github.com/google/closure-compiler/wiki/Managing-Dependencies
         compiler_flags=options.compiler_flags)
 
     logging.info('JavaScript compilation succeeded.')
-    out.write(str(str(compiled_source).encode('utf-8')))
+    out.write(compiled_source.decode('utf-8'))
 
   else:
     logging.error('Invalid value for --output flag.')


### PR DESCRIPTION
Python 2 and Python 3 handle strings differently internally, this change handles that difference.  Unfortunately, this mean that compilation will no longer work with Python2